### PR TITLE
Add volume slider up to 200% for TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is a simple Android timer application for the "Plab 2" exam practice. It pr
 
 - Multi-phase countdown timer for PLAB 2 practice
 - Interface now avoids overlapping device cutouts such as punch-hole cameras
+- Adjustable Text-to-Speech volume up to 200% (with warning for high levels)
 
 ## Building
 

--- a/app/src/main/java/com/example/plab2timerh/MainActivity.kt
+++ b/app/src/main/java/com/example/plab2timerh/MainActivity.kt
@@ -29,6 +29,9 @@ class MainActivity : AppCompatActivity() {
     private lateinit var resetButton: Button
     private lateinit var darkModeSwitch: Switch
     private lateinit var ttsEditText: EditText
+    private lateinit var volumeSeekBar: SeekBar
+    private lateinit var volumeValueTextView: TextView
+    private var ttsVolume: Float = 1.0f
     private lateinit var tts: TextToSpeech
 
     private lateinit var phase1Minutes: NumberPicker
@@ -200,6 +203,26 @@ class MainActivity : AppCompatActivity() {
         resetButton = findViewById(R.id.resetButton)
         darkModeSwitch = findViewById(R.id.darkModeSwitch)
         ttsEditText = findViewById(R.id.ttsEditText)
+        volumeSeekBar = findViewById(R.id.volumeSeekBar)
+        volumeValueTextView = findViewById(R.id.volumeValueTextView)
+
+        volumeSeekBar.max = 200
+        volumeSeekBar.progress = 100
+        volumeValueTextView.text = "100%"
+
+        volumeSeekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
+                ttsVolume = progress / 100f
+                volumeValueTextView.text = "$progress%"
+                if (progress > 100) {
+                    Toast.makeText(this@MainActivity, getString(R.string.volume_warning), Toast.LENGTH_SHORT).show()
+                }
+            }
+
+            override fun onStartTrackingTouch(seekBar: SeekBar?) {}
+
+            override fun onStopTrackingTouch(seekBar: SeekBar?) {}
+        })
 
         phase1Minutes = findViewById(R.id.phase1Minutes)
         phase1Seconds = findViewById(R.id.phase1Seconds)
@@ -381,7 +404,7 @@ class MainActivity : AppCompatActivity() {
     private fun speak(text: String) {
         if (isTtsInitialized) {
             val params = Bundle()
-            params.putFloat(TextToSpeech.Engine.KEY_PARAM_VOLUME, 1.0f)
+            params.putFloat(TextToSpeech.Engine.KEY_PARAM_VOLUME, ttsVolume)
             tts.speak(text, TextToSpeech.QUEUE_FLUSH, params, null)
         }
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -149,6 +149,38 @@
                 app:layout_constraintRight_toRightOf="parent"
                 android:layout_marginTop="16dp" />
 
+            <!-- Volume Slider Label -->
+            <TextView
+                android:id="@+id/volumeLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/volume_label"
+                android:textColor="#E0E0E0"
+                app:layout_constraintTop_toBottomOf="@id/ttsEditText"
+                app:layout_constraintLeft_toLeftOf="parent"
+                android:layout_marginTop="24dp" />
+
+            <!-- Volume Slider -->
+            <SeekBar
+                android:id="@+id/volumeSeekBar"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:max="200"
+                android:progress="100"
+                app:layout_constraintTop_toBottomOf="@id/volumeLabel"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent" />
+
+            <TextView
+                android:id="@+id/volumeValueTextView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="100%"
+                android:textColor="#E0E0E0"
+                app:layout_constraintTop_toBottomOf="@id/volumeSeekBar"
+                app:layout_constraintLeft_toLeftOf="parent"
+                android:layout_marginTop="4dp" />
+
             <!-- Phase 1 Section (1.5 minutes) -->
             <TextView
                 android:id="@+id/section2TextView"
@@ -158,7 +190,7 @@
                 android:textSize="28sp"
                 android:textColor="#E0E0E0"
                 android:fontFamily="sans-serif-medium"
-                app:layout_constraintTop_toBottomOf="@id/ttsEditText"
+                app:layout_constraintTop_toBottomOf="@id/volumeValueTextView"
                 app:layout_constraintLeft_toLeftOf="parent"
                 android:layout_marginTop="24dp" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,6 @@
     <string name="phase3_minutes_desc">Phase 3 Minutes</string>
     <string name="phase3_seconds_desc">Phase 3 Seconds</string>
     <string name="colon">:</string>
+    <string name="volume_label">Volume</string>
+    <string name="volume_warning">Volumes over 100% may damage your speakers.</string>
 </resources>


### PR DESCRIPTION
## Summary
- allow configuring Text-to-Speech output level up to 200%
- show a warning if the user goes above 100%
- display slider in the main activity
- document new feature

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assembleRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ce1cb241483278e7b3c8c5cf26ded