### PR TITLE
Use 10-second increments for seconds pickers and adjust duration calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is a simple Android timer application for the "Plab 2" exam practice. It pr
 
 - Multi-phase countdown timer for PLAB 2 practice
 - Interface now avoids overlapping device cutouts such as punch-hole cameras
+- Phase seconds pickers increment in 10-second steps
 
 ## Building
 

--- a/app/src/main/java/com/example/plab2timerh/MainActivity.kt
+++ b/app/src/main/java/com/example/plab2timerh/MainActivity.kt
@@ -239,19 +239,24 @@ class MainActivity : AppCompatActivity() {
 
     private fun setupNumberPickers() {
         listOf(
-            Triple(phase1Minutes, 0, 59),
-            Triple(phase1Seconds, 0, 59),
-            Triple(phase2Minutes, 0, 59),
-            Triple(phase2Seconds, 0, 59),
-            Triple(phase3Minutes, 0, 59),
-            Triple(phase3Seconds, 0, 59)
-        ).forEach { (picker, min, max) ->
-            picker.minValue = min
+            Pair(phase1Minutes, 59),
+            Pair(phase2Minutes, 59),
+            Pair(phase3Minutes, 59)
+        ).forEach { (picker, max) ->
+            picker.minValue = 0
             picker.maxValue = max
             picker.wrapSelectorWheel = true
         }
 
-        phase1Minutes.value = 1; phase1Seconds.value = 30
+        val secondStepValues = arrayOf("00", "10", "20", "30", "40", "50")
+        listOf(phase1Seconds, phase2Seconds, phase3Seconds).forEach { picker ->
+            picker.minValue = 0
+            picker.maxValue = secondStepValues.lastIndex
+            picker.displayedValues = secondStepValues
+            picker.wrapSelectorWheel = true
+        }
+
+        phase1Minutes.value = 1; phase1Seconds.value = 3
         phase2Minutes.value = 6; phase2Seconds.value = 0
         phase3Minutes.value = 2; phase3Seconds.value = 0
 
@@ -270,9 +275,9 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun updateDurations() {
-        phase1Duration = (phase1Minutes.value * 60L + phase1Seconds.value) * 1000
-        phase2Duration = (phase2Minutes.value * 60L + phase2Seconds.value) * 1000
-        phase3Duration = (phase3Minutes.value * 60L + phase3Seconds.value) * 1000
+        phase1Duration = (phase1Minutes.value * 60L + phase1Seconds.value * 10L) * 1000
+        phase2Duration = (phase2Minutes.value * 60L + phase2Seconds.value * 10L) * 1000
+        phase3Duration = (phase3Minutes.value * 60L + phase3Seconds.value * 10L) * 1000
     }
 
     private fun startSequentialTimer() {
@@ -323,7 +328,7 @@ class MainActivity : AppCompatActivity() {
     
     // Reset NumberPickers to default values
     phase1Minutes.value = 1
-    phase1Seconds.value = 30
+    phase1Seconds.value = 3
     phase2Minutes.value = 6
     phase2Seconds.value = 0
     phase3Minutes.value = 2


### PR DESCRIPTION
### Motivation
- Allow the app's time increments to change from 1-second steps to 10-second steps to match the requested behavior.
- Ensure timer math and default/reset values align with the new 10-second picker representation.

### Description
- Update `setupNumberPickers()` in `app/src/main/java/com/example/plab2timerh/MainActivity.kt` to use minute pickers `0..59` and seconds pickers with displayed values `{"00","10","20","30","40","50"}` and appropriate indices.
- Change `updateDurations()` so seconds are interpreted as `secondsIndex * 10` (i.e. multiply seconds picker value by `10L`) when calculating `phase1Duration`, `phase2Duration`, and `phase3Duration`.
- Adjust default/reset values so `phase1Seconds` uses index `3` (corresponding to `"30"`) and keep other phase defaults aligned with the new indexing.
- Document the new behavior in `README.md` by adding a feature note that the phase seconds pickers increment in 10-second steps.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a96bed7b8832795b89bdf7e3500dc)